### PR TITLE
Fix the runtime - no class found execption

### DIFF
--- a/cxfannotation/build.gradle
+++ b/cxfannotation/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	api group: 'javax.activation', name: 'activation', version: '1.1.1'
 	api group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
 	
-	providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
+	compile group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
 	
 }
 


### PR DESCRIPTION
Hi Himanshu, at the time of runtime, the EndPoint was not getting started because we need httpservlet context. since we are not running this in tomcat, we need to provide servlet runtime explicitly.